### PR TITLE
feat: Refer to other packages from same `pkgsDirectory`

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -43,27 +43,31 @@ in
     perSystem =
       { config, pkgs, ... }:
       let
-        scope = lib.makeScope pkgs.newScope (self: {
-          inherit inputs;
-        });
-
-        flattenAttrs =
+        flattenPkgs =
           path: value:
-          if builtins.isAttrs value then
-            lib.concatMapAttrs (name: flattenAttrs (path ++ [ name ])) value
-          else
+          if lib.isDerivation value then
             {
               ${lib.concatStringsSep config.pkgsNameSeparator path} = value;
-            };
+            }
+          else
+            lib.concatMapAttrs (name: flattenPkgs (path ++ [ name ])) value;
 
-        legacyPackages = lib.filesystem.packagesFromDirectoryRecursive {
-          directory = config.pkgsDirectory;
-          inherit (scope) callPackage;
-        };
+        # makeScope returns some non-derivation values, which we have to filter
+        # out to conform to the flake spec. Assuming that `lib` is from `nixpkgs`,
+        # `callPackage` will only ever return derivations, so this should be fine.
+        legacyPackages = lib.filterAttrs (_: value: builtins.isAttrs value) (
+          lib.makeScope pkgs.newScope (
+            self:
+            lib.filesystem.packagesFromDirectoryRecursive {
+              callPackage = self.newScope { inherit inputs; };
+              directory = config.pkgsDirectory;
+            }
+          )
+        );
       in
       lib.mkIf (config.pkgsDirectory != null) {
         inherit legacyPackages;
-        packages = flattenAttrs [] legacyPackages;
+        packages = flattenPkgs [ ] legacyPackages;
       };
   };
 }


### PR DESCRIPTION
Closes #1.

- Refactored the flattening function to be a lot simpler
- Moved the `packagesFromDirectoryRecursive` call into the `makeScope` call, thereby allowing the definition of interdependent packages in a `pkgsDirectory`

There is one very particular edge case that my code handles worse than the old one: If a user had passed a non-nixpkgs `lib` where `callPackage` is broken in a way that doesn't always return derivations, unexpected things will happen: If the return value is not a set, it will be silently ignored and not included (because of the way I decided to filter the `mkScope` return value). The old implementation would have thrown an appropriate error. I could handle this more specifically, but given the incredibly narrow nature of this edge case, I would prefer to keep the code a little less ugly.