### PR TITLE
feat: recursive scopes

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -49,28 +49,24 @@ in
             {
               ${lib.concatStringsSep separator path} = value;
             }
+          else if lib.isAttrs value then
+            lib.concatMapAttrs (name: flattenPkgs separator (path ++ [ name ])) value
           else
-            lib.concatMapAttrs (name: flattenPkgs separator (path ++ [ name ])) value;
+            # Ignore the functions which makeScope returns
+            { };
+
+        inputsScope = lib.makeScope pkgs.newScope (self: {
+          inherit inputs;
+        });
 
         scopeFromDirectory =
           directory:
-          lib.makeScope pkgs.newScope (
-            self:
-            lib.filesystem.packagesFromDirectoryRecursive {
-              inherit directory;
-              callPackage = self.newScope { inherit inputs; };
-            }
-          );
+          lib.filesystem.packagesFromDirectoryRecursive {
+            inherit directory;
+            inherit (inputsScope) newScope callPackage;
+          };
 
-        scope = scopeFromDirectory config.pkgsDirectory;
-
-        # scope.packages is the second function we passed to makeScope. makeScope
-        # calculates the fixpoint of the scope for us, ie. when we now call this
-        # function with scope, scope.callPackage will "know" all locally defined
-        # packages.
-        # We don't have to worry about the performance of this function call, since
-        # Nix is lazy and doesn't compute any equivalent expression more than once.
-        legacyPackages = scope.packages scope;
+        legacyPackages = scopeFromDirectory config.pkgsDirectory;
       in
       lib.mkIf (config.pkgsDirectory != null) {
         inherit legacyPackages;


### PR DESCRIPTION
Hi :) Here's a PR utilizing the new scopes feature in `packagesFromDirectoryRecursive`.

Sorry for not getting back to you earlier, I had screwed up my DNS settings and didn't receive any e-mails for a period of time…

This change is optional, the old version still works just fine, but now you can also refer to packages from the same folder directly, as outlined in the documentation for `packagesFromDirectoryRecursive`. Also, `legacyPackages` now contains the entire scope instead of just the packages, so theoretically other people could use and expand your scopes directly now.