### PR TITLE
fix: prevent scope helpers from polluting legacyPackages output

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -49,11 +49,8 @@ in
             {
               ${lib.concatStringsSep separator path} = value;
             }
-          else if lib.isAttrs value then
-            lib.concatMapAttrs (name: flattenPkgs separator (path ++ [ name ])) value
           else
-            # Ignore the functions which makeScope returns
-            { };
+            lib.concatMapAttrs (name: flattenPkgs separator (path ++ [ name ])) value;
 
         inputsScope = lib.makeScope pkgs.newScope (self: {
           inherit inputs;
@@ -66,7 +63,21 @@ in
             inherit (inputsScope) newScope callPackage;
           };
 
-        legacyPackages = scopeFromDirectory config.pkgsDirectory;
+        scope = scopeFromDirectory config.pkgsDirectory;
+
+        # lib.makeScope takes two arguments:
+        #   1. A newScope constructor (pkgs.newScope)
+        #   2. A function (self: { packages... }) that builds the package set
+        #
+        # It returns a scope with helper functions AND a special `packages` attribute
+        # that is the second function we passed in. By calling scope.packages with
+        # scope itself as the argument, we:
+        #   - Calculate the fixpoint (all packages can reference each other)
+        #   - Extract just the packages attrset without helper functions (callPackage, etc.)
+        #   - Avoid conflicts with the flake's top-level packages output
+        #
+        # Nix's laziness means this function call has no performance penalty.
+        legacyPackages = scope.packages scope;
       in
       lib.mkIf (config.pkgsDirectory != null) {
         inherit legacyPackages;


### PR DESCRIPTION
  The current implementation exposes scope helper functions (callPackage,
  newScope, overrideScope, packages, recurseForDerivations) in the
  legacyPackages output. This causes conflicts with Nix's attribute
  resolution when building packages using the full path syntax:

    nix build .#packages.aarch64-darwin.foo

  This fails with "error: 'legacyPackages.aarch64-darwin.packages' is not
  an attribute set" because Nix finds legacyPackages.aarch64-darwin.packages
  (a function from makeScope) before checking the flake's packages output.

  The fix uses the standard pattern for extracting packages from a scope:
  calling scope.packages with the scope itself as an argument. This:

  - Calculates the fixpoint so packages can reference each other
  - Returns only the package derivations without helper functions
  - Follows the same pattern used in nixpkgs and other Nix projects
  - Has no performance penalty due to Nix's laziness

  Additionally, flattenPkgs is simplified to remove the now-unnecessary
  filtering logic for functions.

  Fixes building with: nix build .#packages.<system>.<package>
  Preserves: Package inter-references via the scope mechanism