### PR TITLE
fix(flake): restore flattenPkgs else {} to skip non-derivation values

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -49,8 +49,10 @@ in
             {
               ${lib.concatStringsSep separator path} = value;
             }
+          else if lib.isAttrs value then
+            lib.concatMapAttrs (name: flattenPkgs separator (path ++ [ name ])) value
           else
-            lib.concatMapAttrs (name: flattenPkgs separator (path ++ [ name ])) value;
+            { };
 
         inputsScope = lib.makeScope pkgs.newScope (self: {
           inherit inputs;


### PR DESCRIPTION
#4 caused eval errors for me

patch resolves

/cc @hurricanehrndz

<details>

```terminal
at 18:51:20 ❌1 ❯ nix flake show --show-trace
warning: Git tree '/home/sedlund/dev/sedlund/sedlund-systems' is dirty
git+file:///home/sedlund/dev/sedlund/sedlund-systems
├───checks
│   ├───aarch64-darwin
│   │   ├───deploy-activate omitted (use '--all-systems' to show)
│   │   ├───deploy-schema omitted (use '--all-systems' to show)
│   │   └───treefmt omitted (use '--all-systems' to show)
│   ├───aarch64-linux
│   │   ├───deploy-activate omitted (use '--all-systems' to show)
│   │   ├───deploy-schema omitted (use '--all-systems' to show)
│   │   └───treefmt omitted (use '--all-systems' to show)
│   ├───x86_64-darwin
│   │   ├───deploy-activate omitted (use '--all-systems' to show)
│   │   ├───deploy-schema omitted (use '--all-systems' to show)
│   │   └───treefmt omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       ├───deploy-activate: derivation 'deploy-rs-check-activate'
│       ├───deploy-schema: derivation 'jsonschema-deploy-system'
│       └───treefmt: derivation 'treefmt-check'
├───deploy: unknown
├───devShells
│   ├───aarch64-darwin
│   │   ├───bootstrap omitted (use '--all-systems' to show)
│   │   ├───default omitted (use '--all-systems' to show)
│   │   └───kube omitted (use '--all-systems' to show)
│   ├───aarch64-linux
│   │   ├───bootstrap omitted (use '--all-systems' to show)
│   │   ├───default omitted (use '--all-systems' to show)
│   │   └───kube omitted (use '--all-systems' to show)
│   ├───x86_64-darwin
│   │   ├───bootstrap omitted (use '--all-systems' to show)
│   │   ├───default omitted (use '--all-systems' to show)
│   │   └───kube omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       ├───bootstrap: development environment 'devshell'
│       ├───default: development environment 'devshell'
│       └───kube: development environment 'devshell'
├───formatter
│   ├───aarch64-darwin omitted (use '--all-systems' to show)
│   ├───aarch64-linux omitted (use '--all-systems' to show)
│   ├───x86_64-darwin omitted (use '--all-systems' to show)
│   └───x86_64-linux: package 'treefmt'
├───homeConfigurations: unknown
├───homeModules: unknown
├───legacyPackages
│   ├───aarch64-darwin omitted (use '--legacy' to show)
│   ├───aarch64-linux omitted (use '--legacy' to show)
│   ├───x86_64-darwin omitted (use '--legacy' to show)
│   └───x86_64-linux omitted (use '--legacy' to show)
├───nixosConfigurations
│   ├───fra1: NixOS configuration
│   ├───hetz: NixOS configuration
│   ├───pi: NixOS configuration
│   ├───sgp1: NixOS configuration
│   ├───sin1: NixOS configuration
│   ├───wsl: NixOS configuration
│   └───yul1: NixOS configuration
└───packages
    ├───aarch64-darwin
error:
       … while calling anonymous lambda
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/types.nix:879:22:
          878|                 value = mapAttrs (
          879|                   n: v:
             |                      ^
          880|                   if lazy then

       … while evaluating the attribute 'optionalValue.value'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1256:5:
         1255|
         1256|     optionalValue = if isDefined then { value = mergedValue; } else { };
             |     ^
         1257|   };

       … while evaluating a branch condition
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1256:21:
         1255|
         1256|     optionalValue = if isDefined then { value = mergedValue; } else { };
             |                     ^
         1257|   };

       … while evaluating the attribute 'values'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1186:9:
         1185|       {
         1186|         values = defsSorted;
             |         ^
         1187|         inherit (defsFiltered) highestPrio;

       … while evaluating a branch condition
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1180:11:
         1179|           # Avoid sorting if we don't have to.
         1180|           if any (def: def.value._type or "" == "order") defsFiltered.values then
             |           ^
         1181|             sortProperties defsFiltered.values

       … while calling the 'any' builtin
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1180:14:
         1179|           # Avoid sorting if we don't have to.
         1180|           if any (def: def.value._type or "" == "order") defsFiltered.values then
             |              ^
         1181|             sortProperties defsFiltered.values

       … while evaluating the attribute 'values'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1360:7:
         1359|     {
         1360|       values = concatMap (def: if getPrio def == highestPrio then [ (strip def) ] else [ ]) defs;
             |       ^
         1361|       inherit highestPrio;

       … while calling the 'concatMap' builtin
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1360:16:
         1359|     {
         1360|       values = concatMap (def: if getPrio def == highestPrio then [ (strip def) ] else [ ]) defs;
             |                ^
         1361|       inherit highestPrio;

       … while calling the 'concatMap' builtin
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1160:26:
         1159|         # Process mkMerge and mkIf properties.
         1160|         defsNormalized = concatMap (
             |                          ^
         1161|           m:

       … while calling anonymous lambda
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1161:11:
         1160|         defsNormalized = concatMap (
         1161|           m:
             |           ^
         1162|           map (

       … while calling the 'map' builtin
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1162:11:
         1161|           m:
         1162|           map (
             |           ^
         1163|             value:

       … while evaluating definitions from `/nix/store/lscb3irg1bmxaywmpbcs1ix52519dwsv-source/modules/transposition.nix':

       … from call site
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1171:80:
         1170|               }
         1171|           ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
             |                                                                                ^
         1172|         ) defs;

       … while calling 'dischargeProperties'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1311:5:
         1310|   dischargeProperties =
         1311|     def:
             |     ^
         1312|     if def._type or "" == "merge" then

       … while evaluating a branch condition
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1312:5:
         1311|     def:
         1312|     if def._type or "" == "merge" then
             |     ^
         1313|       concatMap dischargeProperties def.contents

       … while evaluating the attribute 'value'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/types.nix:819:15:
          818|               inherit (def) file;
          819|               value = v;
             |               ^
          820|             }) def.value

       … from call site
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/types.nix:819:15:
          818|               inherit (def) file;
          819|               value = v;
             |               ^
          820|             }) def.value

       … while calling anonymous lambda
         at /nix/store/lscb3irg1bmxaywmpbcs1ix52519dwsv-source/modules/transposition.nix:104:22:
          103|           mapAttrs
          104|             (system: v: v.${attrName} or (
             |                      ^
          105|               abort ''

       … from call site
         at /nix/store/lscb3irg1bmxaywmpbcs1ix52519dwsv-source/modules/transposition.nix:104:25:
          103|           mapAttrs
          104|             (system: v: v.${attrName} or (
             |                         ^
          105|               abort ''

       … while calling anonymous lambda
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/attrsets.nix:1188:17:
         1187|         mapAttrs (
         1188|           name: value:
             |                 ^
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value

       … from call site
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/attrsets.nix:1189:85:
         1188|           name: value:
         1189|           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value
             |                                                                                     ^
         1190|         );

       … while calling anonymous lambda
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:275:71:
          274|           # For definitions that have an associated option
          275|           declaredConfig = mapAttrsRecursiveCond (v: !isOption v) (_: v: v.value) options;
             |                                                                       ^
          276|

       … while evaluating the attribute 'value'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       … while evaluating the option `perSystem.aarch64-darwin.packages':

       … while evaluating the attribute 'mergedValue'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1192:5:
         1191|     # Type-check the remaining definitions, and merge them. Or throw if no definitions.
         1192|     mergedValue =
             |     ^
         1193|       if isDefined then

       … while evaluating a branch condition
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1193:7:
         1192|     mergedValue =
         1193|       if isDefined then
             |       ^
         1194|         if type.merge ? v2 then

       (8 duplicate frames omitted)

       … while evaluating definitions from `/nix/store/wk9awb92g9fqi5jgcqjiwcnd8nb98937-source/flake-module.nix, via option perSystem':

       … from call site
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1171:80:
         1170|               }
         1171|           ) (addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
             |                                                                                ^
         1172|         ) defs;

       … while calling 'dischargeProperties'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1311:5:
         1310|   dischargeProperties =
         1311|     def:
             |     ^
         1312|     if def._type or "" == "merge" then

       … from call site
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1316:31:
         1315|       if isBool def.condition then
         1316|         if def.condition then dischargeProperties def.content else [ ]
             |                               ^
         1317|       else

       … while calling 'dischargeProperties'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1311:5:
         1310|   dischargeProperties =
         1311|     def:
             |     ^
         1312|     if def._type or "" == "merge" then

       … while evaluating a branch condition
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1312:5:
         1311|     def:
         1312|     if def._type or "" == "merge" then
             |     ^
         1313|       concatMap dischargeProperties def.contents

       … while evaluating the attribute 'content'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/modules.nix:1471:23:
         1470|     _type = "if";
         1471|     inherit condition content;
             |                       ^
         1472|   };

       … from call site
         at /nix/store/wk9awb92g9fqi5jgcqjiwcnd8nb98937-source/flake-module.nix:84:20:
           83|         inherit legacyPackages;
           84|         packages = flattenPkgs config.pkgsNameSeparator [ ] legacyPackages;
             |                    ^
           85|       };

       … while calling 'flattenPkgs'
         at /nix/store/wk9awb92g9fqi5jgcqjiwcnd8nb98937-source/flake-module.nix:47:28:
           46|         flattenPkgs =
           47|           separator: path: value:
             |                            ^
           48|           if lib.isDerivation value then

       … from call site
         at /nix/store/wk9awb92g9fqi5jgcqjiwcnd8nb98937-source/flake-module.nix:53:13:
           52|           else
           53|             lib.concatMapAttrs (name: flattenPkgs separator (path ++ [ name ])) value;
             |             ^
           54|

       … while calling 'concatMapAttrs'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/attrsets.nix:374:23:
          373|   */
          374|   concatMapAttrs = f: v: foldl' mergeAttrs { } (attrValues (mapAttrs f v));
             |                       ^
          375|

       … while calling the 'foldl'' builtin
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/attrsets.nix:374:26:
          373|   */
          374|   concatMapAttrs = f: v: foldl' mergeAttrs { } (attrValues (mapAttrs f v));
             |                          ^
          375|

       … while calling 'mergeAttrs'
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/trivial.nix:310:19:
          309|   */
          310|   mergeAttrs = x: y: x // y;
             |                   ^
          311|

       … in the right operand of the update (//) operator
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/trivial.nix:310:24:
          309|   */
          310|   mergeAttrs = x: y: x // y;
             |                        ^
          311|

       … from call site
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/trivial.nix:310:27:
          309|   */
          310|   mergeAttrs = x: y: x // y;
             |                           ^
          311|

       (25 duplicate frames omitted)

       … while calling the 'attrValues' builtin
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/attrsets.nix:374:49:
          373|   */
          374|   concatMapAttrs = f: v: foldl' mergeAttrs { } (attrValues (mapAttrs f v));
             |                                                 ^
          375|

       … while calling the 'mapAttrs' builtin
         at /nix/store/hcwyk6l4vm5r05zsl6pkskfnqc6bh6kz-source/lib/attrsets.nix:374:61:
          373|   */
          374|   concatMapAttrs = f: v: foldl' mergeAttrs { } (attrValues (mapAttrs f v));
             |                                                             ^
          375|

       … while evaluating the second argument passed to builtins.mapAttrs

       error: expected a set but found a Boolean: false
```

</details>