### PR TITLE
Recursively extract packages from scope

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -77,7 +77,22 @@ in
         #   - Avoid conflicts with the flake's top-level packages output
         #
         # Nix's laziness means this function call has no performance penalty.
-        legacyPackages = scope.packages scope;
+        extractPackages = scope:
+          let
+            shouldRecurse =
+              lib.isAttrs scope
+              && !(lib.isDerivation scope)
+              && scope ? "packages"
+              && lib.isFunction scope.packages
+            ;
+            mappedSet =
+              lib.mapAttrs
+                (_: extractPackages)
+                (scope.packages scope);
+          in
+          if shouldRecurse then mappedSet else scope;
+
+        legacyPackages = extractPackages scope;
       in
       lib.mkIf (config.pkgsDirectory != null) {
         inherit legacyPackages;


### PR DESCRIPTION
The function `lib.packagesFromDirectoryRecursive` can return attrset of packages within a namespace. In this case, the previous approach removed scope helper function only from the top level of attrset. This method handles all nested namespaces too.