### PR TITLE
Add `pkgsRespectPlatforms` option to omit platform-incompatible packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This module has the following configuration attributes:
   value is `null`.
 - `pkgsNameSeparator`: The separator used to concatenate the package name. The
   default value is `/`.
-- `respectPlatforms`: Whether to omit packages whose
+- `pkgsFilterByPlatforms`: Whether to omit packages whose
   `meta.platforms`/`meta.badPlatforms` exclude the current system. The default
   value is `false`.
 

--- a/README.md
+++ b/README.md
@@ -170,11 +170,13 @@ This module has the following configuration attributes:
       `packages` attrset. Filtered-out packages still remain reachable through
       `legacyPackages`, which is never filtered.
 
-      **Note:** Enabling this option incurs a performance penalty, since
-      accessing any part of `packages.<system>` requires Nix to check *every*
+      **Note:** Enabling this option incurs a slight performance penalty, since
+      accessing any part of `packages.<system>` requires Nix to check _every_
       package's `meta`, even when only one package is requested. The cost grows
       with the number of packages and with how expensive they are to evaluate.
-      However, the should be negligible for small package sets.
+      However, this should be negligible for small package sets. Also beware
+      that packages whose `meta` fails to evaluate will make the _entire_
+      package set unusable.
 
       _See also: [Relevant
       issue](https://github.com/drupol/pkgs-by-name-for-flake-parts/issues/7)._

--- a/README.md
+++ b/README.md
@@ -155,6 +155,30 @@ This module has the following configuration attributes:
   value is `null`.
 - `pkgsNameSeparator`: The separator used to concatenate the package name. The
   default value is `/`.
+- `respectPlatforms`: Whether to omit packages whose
+  `meta.platforms`/`meta.badPlatforms` exclude the current system. The default
+  value is `false`.
+
+  <details>
+    <summary>Click to see explanation...</summary>
+
+    - **`false` (default):** All packages will be included in
+      `packages.<system>`, regardless of whether the package states itself to be
+      incompatible. This *will* result in a failure to evaluate on that
+      incompatible system, breaking things like `nix flake check`.
+    - **`true`:** Incompatible packages will be filtered out of the flake's
+      `packages` attrset. Filtered-out packages still remain reachable through
+      `legacyPackages`, which is never filtered.
+
+      **Note:** Enabling this option incurs a performance penalty, since
+      accessing any part of `packages.<system>` requires Nix to check *every*
+      package's `meta`, even when only one package is requested. The cost grows
+      with the number of packages and with how expensive they are to evaluate.
+      However, the should be negligible for small package sets.
+
+      _See also: [Relevant
+      issue](https://github.com/drupol/pkgs-by-name-for-flake-parts/issues/7)._
+  </details>
 
 ## Example
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -34,6 +34,17 @@ in
               The separator to use when flattening package names.
             '';
           };
+
+          respectPlatforms = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Whether to restrict the generated `packages` output to
+              derivations whose `meta.platforms`/`meta.badPlatforms` include
+              the current system. Filtered-out derivations remain reachable
+              through `legacyPackages`.
+            '';
+          };
         };
       }
     );
@@ -43,12 +54,16 @@ in
     perSystem =
       { config, pkgs, ... }:
       let
+        inherit (pkgs.stdenv) hostPlatform;
+
         flattenPkgs =
           separator: path: value:
           if lib.isDerivation value then
-            {
-              ${lib.concatStringsSep separator path} = value;
-            }
+            lib.optionalAttrs
+              (!config.respectPlatforms || lib.meta.availableOn hostPlatform value)
+              {
+                ${lib.concatStringsSep separator path} = value;
+              }
           else if lib.isAttrs value then
             lib.concatMapAttrs (name: flattenPkgs separator (path ++ [ name ])) value
           else

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -35,7 +35,7 @@ in
             '';
           };
 
-          respectPlatforms = mkOption {
+          pkgsFilterByPlatforms = mkOption {
             type = types.bool;
             default = false;
             description = ''
@@ -60,7 +60,7 @@ in
           separator: path: value:
           if lib.isDerivation value then
             lib.optionalAttrs
-              (!config.respectPlatforms || lib.meta.availableOn hostPlatform value)
+              (!config.pkgsFilterByPlatforms || lib.meta.availableOn hostPlatform value)
               {
                 ${lib.concatStringsSep separator path} = value;
               }

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -43,6 +43,10 @@ in
               derivations whose `meta.platforms`/`meta.badPlatforms` include
               the current system. Filtered-out derivations remain reachable
               through `legacyPackages`.
+
+              Note: Enabling this requires evaluating *every* package's `meta`
+              when accessing *any* part of `packages.<system>`. Negligible for
+              small pkgs sets, but cost grows with set size and eval cost.
             '';
           };
         };


### PR DESCRIPTION
Adds a new `perSystem` option: **`pkgsRespectPlatforms`** (`bool`, default `false`).

- When enabled, packages whose `meta.platforms`/`meta.badPlatforms` exclude the current system are omitted from `packages.<system>`. Filtered-out packages remain reachable through `legacyPackages`.

- Without it, a single package that does *not* support one of the declared systems makes `packages.<system>` fail to evaluate on that system, breaking things like `nix flake check`.

Packages without `meta.platforms`/`meta.badPlatforms` are still considered available everywhere. And with the default of `respectPlatforms = false`, evaluation behaves as it did before this change.

Closes #7. I also added some additional detail to the README based on @roberth's [comment](https://github.com/drupol/pkgs-by-name-for-flake-parts/issues/7#issuecomment-3865456109) from that issue, so users are aware of the evaluation performance implications of enabling this option.